### PR TITLE
Fix circular reference

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl extension Test-EasyMock
 
 {{$NEXT}}
 
+  * Fix circular reference.
+
 0.07 2013-07-05T03:12:05Z
 
   * Use Data::Dump instead of Data::Dumper.

--- a/cpanfile
+++ b/cpanfile
@@ -17,6 +17,7 @@ on test => sub {
     requires 'List::MoreUtils';
     requires 'Test::More';
     requires 'Test::Tester';
+    requires 'Test::LeakTrace';
 };
 
 on develop => sub {

--- a/cpanfile
+++ b/cpanfile
@@ -17,7 +17,6 @@ on test => sub {
     requires 'List::MoreUtils';
     requires 'Test::More';
     requires 'Test::Tester';
-    requires 'Test::LeakTrace';
 };
 
 on develop => sub {

--- a/lib/Test/EasyMock.pm
+++ b/lib/Test/EasyMock.pm
@@ -107,7 +107,7 @@ sub create_mock {
     return $control->create_mock;
 }
 
-=head2 expect($expectation)
+=head2 expect(<a mock method call>)
 
 Record a method invocation and behavior.
 
@@ -155,8 +155,7 @@ Set I<die> behavior as as stub to the expectation.
 
 =cut
 sub expect {
-    my ($expectation) = @_;
-    return __delegate(expect => ($expectation->mock, $expectation));
+    return __delegate(expect => @_);
 }
 
 =head2 replay($mock [, $mock2 ...])

--- a/lib/Test/EasyMock/Expectation.pm
+++ b/lib/Test/EasyMock/Expectation.pm
@@ -8,11 +8,10 @@ Test::EasyMock::Expectation - A expected behavior object.
 
 =cut
 use Carp qw(croak);
-use Scalar::Util qw(refaddr);
 
 =head1 CONSTRUCTORS
 
-=head2 new({mock=>$mock, method=>$method, args=>$args})
+=head2 new(method=>$method, args=>$args})
 
 Create a instance.
 
@@ -20,21 +19,10 @@ Create a instance.
 sub new {
     my ($class, $args) = @_;
     return bless {
-        _mock => $args->{mock},
         _method => $args->{method},
         _args => $args->{args},
         _results => [ { code => sub { return; }, implicit => 1 } ],
     }, $class;
-}
-
-=head1 PROPERTIES
-
-=head2 mock - A related mock object.
-
-=cut
-sub mock {
-    my ($self) = @_;
-    return $self->{_mock};
 }
 
 =head1 METHODS
@@ -112,8 +100,7 @@ It is tested whether the specified argument matches.
 =cut
 sub matches {
     my ($self, $args) = @_;
-    return refaddr($self->{_mock}) == refaddr($args->{mock})
-        && $self->{_method} eq $args->{method}
+    return $self->{_method} eq $args->{method}
         && $self->{_args}->matches($args->{args});
 }
 

--- a/lib/Test/EasyMock/MockControl.pm
+++ b/lib/Test/EasyMock/MockControl.pm
@@ -10,7 +10,7 @@ Test::EasyMock::MockControl - Control behavior of the mock object.
 use Data::Dump qw(pp);
 use Data::Util qw(is_instance);
 use List::Util qw(first);
-use Scalar::Util qw(blessed refaddr);
+use Scalar::Util qw(blessed);
 use Test::Builder;
 use Test::EasyMock::ArgumentsMatcher;
 use Test::EasyMock::Expectation;
@@ -33,7 +33,7 @@ sub create_control {
 
 =head1 CONSTRUCTORS
 
-=head2 new($expectation)
+=head2 new([$module|$object])
 
 Create a instance.
 
@@ -110,13 +110,13 @@ Record the method invocation.
 =cut
 sub record_method_invocation {
     my ($self, $mock, $method, @args) = @_;
-    return Test::EasyMock::Expectation->new({
-        mock => $mock,
+    my $expectation = Test::EasyMock::Expectation->new({
         method => $method,
         args => is_instance($args[0], 'Test::EasyMock::ArgumentsMatcher')
             ? $args[0]
             : Test::EasyMock::ArgumentsMatcher->new(\@args),
     });
+    return ($mock, $expectation);
 }
 
 =head2 find_expectation($args)

--- a/t/01.total.t
+++ b/t/01.total.t
@@ -14,10 +14,11 @@ BEGIN {
            });
 }
 use Test::Deep qw(ignore);
+use Test::LeakTrace;
 
 # ----
 # Tests.
-subtest 'default mock' => sub {
+subtest 'default mock' => sub { no_leaks_ok {
     my $mock = create_mock();
 
     subtest 'array arguments and array result' => sub {
@@ -183,7 +184,7 @@ subtest 'default mock' => sub {
         replay($mock);
         verify($mock);          # pass
     };
-};
+} 'no memory leaks'; };
 
 
 # ----

--- a/t/01.total.t
+++ b/t/01.total.t
@@ -14,11 +14,11 @@ BEGIN {
            });
 }
 use Test::Deep qw(ignore);
-use Test::LeakTrace;
+use Scalar::Util qw(weaken);
 
 # ----
 # Tests.
-subtest 'default mock' => sub { no_leaks_ok {
+subtest 'default mock' => sub {
     my $mock = create_mock();
 
     subtest 'array arguments and array result' => sub {
@@ -184,7 +184,14 @@ subtest 'default mock' => sub { no_leaks_ok {
         replay($mock);
         verify($mock);          # pass
     };
-} 'no memory leaks'; };
+
+    subtest 'destroy mock object' => sub {
+        my $weak_ref_mock = $mock;
+        weaken($weak_ref_mock);
+        undef($mock);
+        is($weak_ref_mock, undef, 'mock is destroied.');
+    };
+};
 
 
 # ----


### PR DESCRIPTION
循環参照が発生していたのを修正しました。
以下の参照関係にあったため、Expectation の mock プロパティを除去することで、循環参照を解消しました。
MockObject -> MockControl -> Expectation -> MockObject
